### PR TITLE
Use Net::DNS::Resolver's retry functionality to check other NSs

### DIFF
--- a/t/MockResolver.pm
+++ b/t/MockResolver.pm
@@ -32,6 +32,11 @@ sub _make_proxy {
                 if $ENV{VERBOSE};
             return $self->{next_fake_packet};
         }
+        if ($method eq "send" && $fr->{$_[0]}) {
+            Test::More::note("mock DNS resolver doing fake send() of $_[0]\n")
+                if $ENV{VERBOSE};
+            return $fr->{$_[0]};
+        }
         # No verbose conditional on this one because it shouldn't happen:
         Test::More::note("Calling through to Net::DNS::Resolver proxy method '$method'");
         return $self->{proxy}->$method(@_);


### PR DESCRIPTION
(This is the pull request for [RT#106791](https://rt.cpan.org/Public/Bug/Display.html?id=106791).)

Net::DNS::Paranoid uses Resolver's bgsend method, which has no support for retries, timeouts, or alternate nameservers.  Therefore, if the primary NS goes down, the entire app goes down.  This defeats the purpose of having a backup NS in the first place.

This pull request calculates the appropriate retry and timeout settings for Net::DNS::Resolver, and uses  the 'send' method to take advantage of its retry functionality.
