### PR TITLE
Switch to `nip.io`, from `xip.io` in this test.

### DIFF
--- a/t/01_simple.t
+++ b/t/01_simple.t
@@ -78,15 +78,15 @@ subtest "can't do decimal/octal IPs" => sub {
         [ undef, 'DNS lookup resulted in bad host.' ] );
 };
 
-subtest "this domain is okay.  50.112.116.235.xip.io isn't blocked" => sub {
-    is_deeply( [ $dns->resolve('50.112.116.235.xip.io') ],
+subtest "this domain is okay.  50.112.116.235.nip.io isn't blocked" => sub {
+    is_deeply( [ $dns->resolve('50.112.116.235.nip.io') ],
         [ ['50.112.116.235'], undef ] );
 };
 
 subtest 'internal. bad.  blocked by default by module.' => sub {
     is_deeply( [ $dns->resolve('10.2.3.4') ],
         [ undef, 'DNS lookup resulted in bad host.' ] );
-    is_deeply( [ $dns->resolve('50.112.116.235.xip.io') ],
+    is_deeply( [ $dns->resolve('50.112.116.235.nip.io') ],
         [ ['50.112.116.235'], undef ], 'ok' );
 };
 


### PR DESCRIPTION
`xip.io` stopped working long ago, and `nip.io` provides a similar service and should be working.  Update test accordingly.

Resolves #4